### PR TITLE
add license to gemspec

### DIFF
--- a/modularity.gemspec
+++ b/modularity.gemspec
@@ -5,6 +5,7 @@ require 'modularity/version'
 Gem::Specification.new do |s|
   s.name = %q{modularity}
   s.version = Modularity::VERSION
+  s.licenses = ["MIT"]
   s.authors = ["Henning Koch"]
   s.email = %q{github@makandra.de}
   s.homepage = %q{http://github.com/makandra/modularity}


### PR DESCRIPTION
Having the license info in the gemspec helps generating a license report with `bundle license`
