### PR TITLE
Add keyword support for ruby 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,13 @@ jobs:
         include:
         - ruby: 2.5.7
           gemfile: Gemfile
+        - ruby: 2.6.10
+          gemfile: Gemfile
         - ruby: 2.7.4
           gemfile: Gemfile
         - ruby: 3.0.2
+          gemfile: Gemfile
+        - ruby: 3.1.2
           gemfile: Gemfile
     env:
       BUNDLE_GEMFILE: "${{ matrix.gemfile }}"

--- a/spec/modularity/as_trait_spec.rb
+++ b/spec/modularity/as_trait_spec.rb
@@ -201,6 +201,35 @@ describe Modularity::AsTrait do
 
       end
 
+      it 'passes keyword args to the block given to as_trait' do
+
+        module ModuleWithKeywordArgs
+          as_trait do |hash, required_kwarg:, optional_kwarg: 'foo'|
+            define_method :passed_hash do
+              hash
+            end
+
+            define_method :required_keyword do
+              required_kwarg
+            end
+
+            define_method :optional_keyword do
+              optional_kwarg
+            end
+
+          end
+        end
+
+        @doing_class.class_eval do
+          include ModuleWithKeywordArgs[{ first_hash_key: 'value_one', second_hash_key: 'value_two' }, required_kwarg: 'bar']
+        end
+
+        instance = @doing_class.new
+        instance.passed_hash.should eq({ first_hash_key: 'value_one', second_hash_key: 'value_two' })
+        instance.required_keyword.should eq('bar')
+        instance.optional_keyword.should eq('foo')
+      end
+
     end
 
   end


### PR DESCRIPTION
In the current implementation, keyword arguments would no longer be supported for parameterized traits in Ruby 3. 
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

In the linked article it's suggested to use the helper_method `ruby2_keywords` introduced in Ruby 2.7, but that only seems to work for instance methods, which is not applicable in our case. 

Moreover, I decided to use the new syntax from Ruby 2.7. on already, in order to prevent deprecation messages.